### PR TITLE
fix crash when packet gets received with an invalid ID

### DIFF
--- a/Terraria/Main.cs
+++ b/Terraria/Main.cs
@@ -469,14 +469,6 @@ namespace Terraria
 
 		public static int rxMsg;
 
-		public static int[] rxMsgType;
-
-		public static int[] rxDataType;
-
-		public static int[] txMsgType;
-
-		public static int[] txDataType;
-
 		public static float uCarry;
 
 		public static bool drawSkip;
@@ -2654,10 +2646,6 @@ namespace Terraria
 			Main.rxData = 0;
 			Main.txMsg = 0;
 			Main.rxMsg = 0;
-			Main.rxMsgType = new int[Main.maxMsg];
-			Main.rxDataType = new int[Main.maxMsg];
-			Main.txMsgType = new int[Main.maxMsg];
-			Main.txDataType = new int[Main.maxMsg];
 			Main.uCarry = 0f;
 			Main.drawSkip = false;
 			Main.fpsCount = 0;
@@ -12681,7 +12669,6 @@ namespace Terraria
 					vector2 = new Vector2();
 					spriteBatch1.DrawString(spriteFont1, str1, vector216, white1, 0f, vector2, single25, SpriteEffects.None, 0f);
 					num26 = num26 + 30;
-					str1 = string.Concat("rx:", string.Format("{0:0,0}", Main.rxMsgType[b]));
 					SpriteBatch spriteBatch2 = Main.spriteBatch;
 					SpriteFont spriteFont2 = Main.fontMouseText;
 					Vector2 vector217 = new Vector2((float)num26, (float)num27);
@@ -12689,7 +12676,6 @@ namespace Terraria
 					vector2 = new Vector2();
 					spriteBatch2.DrawString(spriteFont2, str1, vector217, white2, 0f, vector2, single25, SpriteEffects.None, 0f);
 					num26 = num26 + 70;
-					str1 = string.Format("{0:0,0}", Main.rxDataType[b]);
 					SpriteBatch spriteBatch3 = Main.spriteBatch;
 					SpriteFont spriteFont3 = Main.fontMouseText;
 					Vector2 vector218 = new Vector2((float)num26, (float)num27);
@@ -12705,7 +12691,6 @@ namespace Terraria
 					vector2 = new Vector2();
 					spriteBatch4.DrawString(spriteFont4, str1, vector219, white4, 0f, vector2, single25, SpriteEffects.None, 0f);
 					num26 = num26 + 30;
-					str1 = string.Concat("tx:", string.Format("{0:0,0}", Main.txMsgType[b]));
 					SpriteBatch spriteBatch5 = Main.spriteBatch;
 					SpriteFont spriteFont5 = Main.fontMouseText;
 					Vector2 vector220 = new Vector2((float)num26, (float)num27);
@@ -12713,7 +12698,6 @@ namespace Terraria
 					vector2 = new Vector2();
 					spriteBatch5.DrawString(spriteFont5, str1, vector220, white5, 0f, vector2, single25, SpriteEffects.None, 0f);
 					num26 = num26 + 70;
-					str1 = string.Format("{0:0,0}", Main.txDataType[b]);
 					SpriteBatch spriteBatch6 = Main.spriteBatch;
 					SpriteFont spriteFont6 = Main.fontMouseText;
 					Vector2 vector221 = new Vector2((float)num26, (float)num27);

--- a/Terraria/NetMessage.cs
+++ b/Terraria/NetMessage.cs
@@ -1003,8 +1003,6 @@ namespace Terraria
 						NetMessage.buffer[num].spamCount++;
 						Main.txMsg++;
 						Main.txData += num19;
-						Main.txMsgType[msgType]++;
-						Main.txDataType[msgType] += num19;
 						Netplay.Connection.Socket.AsyncSend(NetMessage.buffer[num].writeBuffer, 0, num19, new SocketSendCallback(Netplay.Connection.ClientWriteCallBack), null);
 						goto IL_2A90;
 					}
@@ -1026,8 +1024,6 @@ namespace Terraria
 									NetMessage.buffer[num20].spamCount++;
 									Main.txMsg++;
 									Main.txData += num19;
-									Main.txMsgType[msgType]++;
-									Main.txDataType[msgType] += num19;
 									Netplay.Clients[num20].Socket.AsyncSend(NetMessage.buffer[num].writeBuffer, 0, num19, new SocketSendCallback(Netplay.Clients[num20].ServerWriteCallBack), null);
 								}
 								catch (Exception ex)
@@ -1052,8 +1048,6 @@ namespace Terraria
 									NetMessage.buffer[num21].spamCount++;
 									Main.txMsg++;
 									Main.txData += num19;
-									Main.txMsgType[msgType]++;
-									Main.txDataType[msgType] += num19;
 									Netplay.Clients[num21].Socket.AsyncSend(NetMessage.buffer[num].writeBuffer, 0, num19, new SocketSendCallback(Netplay.Clients[num21].ServerWriteCallBack), null);
 								}
 								catch (Exception ex)
@@ -1103,8 +1097,6 @@ namespace Terraria
 										NetMessage.buffer[num22].spamCount++;
 										Main.txMsg++;
 										Main.txData += num19;
-										Main.txMsgType[msgType]++;
-										Main.txDataType[msgType] += num19;
 										Netplay.Clients[num22].Socket.AsyncSend(NetMessage.buffer[num].writeBuffer, 0, num19, new SocketSendCallback(Netplay.Clients[num22].ServerWriteCallBack), null);
 									}
 									catch (Exception ex)
@@ -1156,8 +1148,6 @@ namespace Terraria
 										NetMessage.buffer[num23].spamCount++;
 										Main.txMsg++;
 										Main.txData += num19;
-										Main.txMsgType[msgType]++;
-										Main.txDataType[msgType] += num19;
 										Netplay.Clients[num23].Socket.AsyncSend(NetMessage.buffer[num].writeBuffer, 0, num19, new SocketSendCallback(Netplay.Clients[num23].ServerWriteCallBack), null);
 									}
 									catch (Exception ex)
@@ -1183,8 +1173,6 @@ namespace Terraria
 									NetMessage.buffer[num24].spamCount++;
 									Main.txMsg++;
 									Main.txData += num19;
-									Main.txMsgType[msgType]++;
-									Main.txDataType[msgType] += num19;
 									Netplay.Clients[num24].Socket.AsyncSend(NetMessage.buffer[num].writeBuffer, 0, num19, new SocketSendCallback(Netplay.Clients[num24].ServerWriteCallBack), null);
 								}
 								catch (Exception ex)
@@ -1235,8 +1223,6 @@ namespace Terraria
 										NetMessage.buffer[num25].spamCount++;
 										Main.txMsg++;
 										Main.txData += num19;
-										Main.txMsgType[msgType]++;
-										Main.txDataType[msgType] += num19;
 										Netplay.Clients[num25].Socket.AsyncSend(NetMessage.buffer[num].writeBuffer, 0, num19, new SocketSendCallback(Netplay.Clients[num25].ServerWriteCallBack), null);
 									}
 									catch (Exception ex)
@@ -1262,8 +1248,6 @@ namespace Terraria
 									NetMessage.buffer[num26].spamCount++;
 									Main.txMsg++;
 									Main.txData += num19;
-									Main.txMsgType[msgType]++;
-									Main.txDataType[msgType] += num19;
 									Netplay.Clients[num26].Socket.AsyncSend(NetMessage.buffer[num].writeBuffer, 0, num19, new SocketSendCallback(Netplay.Clients[num26].ServerWriteCallBack), null);
 								}
 								catch (Exception ex)
@@ -1285,8 +1269,6 @@ namespace Terraria
 						NetMessage.buffer[remoteClient].spamCount++;
 						Main.txMsg++;
 						Main.txData += num19;
-						Main.txMsgType[msgType]++;
-						Main.txDataType[msgType] += num19;
 						Netplay.Clients[remoteClient].Socket.AsyncSend(NetMessage.buffer[num].writeBuffer, 0, num19, new SocketSendCallback(Netplay.Clients[remoteClient].ServerWriteCallBack), null);
 					}
 					catch (Exception ex)

--- a/Terraria/Netplay.cs
+++ b/Terraria/Netplay.cs
@@ -83,13 +83,6 @@ namespace Terraria
 			Main.rxData = 0;
 			Main.txMsg = 0;
 			Main.txData = 0;
-			for (int i = 0; i < Main.maxMsg; i++)
-			{
-				Main.rxMsgType[i] = 0;
-				Main.rxDataType[i] = 0;
-				Main.txMsgType[i] = 0;
-				Main.txDataType[i] = 0;
-			}
 		}
 		public static void ResetSections()
 		{

--- a/Terraria/messageBuffer.cs
+++ b/Terraria/messageBuffer.cs
@@ -79,8 +79,6 @@ namespace Terraria
 			num1 = this.readBuffer[start];
 			Main.rxMsg = Main.rxMsg + 1;
 			Main.rxData = Main.rxData + length;
-			Main.rxMsgType[num1] = Main.rxMsgType[num1] + 1;
-			Main.rxDataType[num1] = Main.rxDataType[num1] + length;
 			if (Main.netMode == 1 && Netplay.Connection.StatusMax > 0)
 			{
 				RemoteServer connection = Netplay.Connection;


### PR DESCRIPTION
Server will crash with an out of bounds when sent a packet with an invalid ID.  Killed Main.rx/tx fields as they are only used for a poorly implemented net diagnostics feature.
