### PR TITLE
Pressing CTRL+C now saves world and quits the server properly

### DIFF
--- a/Terraria/Main.cs
+++ b/Terraria/Main.cs
@@ -34391,6 +34391,15 @@ namespace Terraria
 			{
 				Console.Write(": ");
 				string lower = Console.ReadLine();
+		
+				if (lower == null) {
+					Console.WriteLine("Quit");
+					WorldFile.saveWorld();
+					Netplay.disconnect = true;
+					SocialAPI.Shutdown();
+					break;
+				}
+
 				string str = lower;
 				lower = lower.ToLower();
 				try

--- a/Terraria/Main.cs
+++ b/Terraria/Main.cs
@@ -469,6 +469,14 @@ namespace Terraria
 
 		public static int rxMsg;
 
+		public static int[] rxMsgType;
+
+		public static int[] rxDataType;
+
+		public static int[] txMsgType;
+
+		public static int[] txDataType;
+
 		public static float uCarry;
 
 		public static bool drawSkip;
@@ -2646,6 +2654,10 @@ namespace Terraria
 			Main.rxData = 0;
 			Main.txMsg = 0;
 			Main.rxMsg = 0;
+			Main.rxMsgType = new int[Main.maxMsg];
+			Main.rxDataType = new int[Main.maxMsg];
+			Main.txMsgType = new int[Main.maxMsg];
+			Main.txDataType = new int[Main.maxMsg];
 			Main.uCarry = 0f;
 			Main.drawSkip = false;
 			Main.fpsCount = 0;
@@ -12669,6 +12681,7 @@ namespace Terraria
 					vector2 = new Vector2();
 					spriteBatch1.DrawString(spriteFont1, str1, vector216, white1, 0f, vector2, single25, SpriteEffects.None, 0f);
 					num26 = num26 + 30;
+					str1 = string.Concat("rx:", string.Format("{0:0,0}", Main.rxMsgType[b]));
 					SpriteBatch spriteBatch2 = Main.spriteBatch;
 					SpriteFont spriteFont2 = Main.fontMouseText;
 					Vector2 vector217 = new Vector2((float)num26, (float)num27);
@@ -12676,6 +12689,7 @@ namespace Terraria
 					vector2 = new Vector2();
 					spriteBatch2.DrawString(spriteFont2, str1, vector217, white2, 0f, vector2, single25, SpriteEffects.None, 0f);
 					num26 = num26 + 70;
+					str1 = string.Format("{0:0,0}", Main.rxDataType[b]);
 					SpriteBatch spriteBatch3 = Main.spriteBatch;
 					SpriteFont spriteFont3 = Main.fontMouseText;
 					Vector2 vector218 = new Vector2((float)num26, (float)num27);
@@ -12691,6 +12705,7 @@ namespace Terraria
 					vector2 = new Vector2();
 					spriteBatch4.DrawString(spriteFont4, str1, vector219, white4, 0f, vector2, single25, SpriteEffects.None, 0f);
 					num26 = num26 + 30;
+					str1 = string.Concat("tx:", string.Format("{0:0,0}", Main.txMsgType[b]));
 					SpriteBatch spriteBatch5 = Main.spriteBatch;
 					SpriteFont spriteFont5 = Main.fontMouseText;
 					Vector2 vector220 = new Vector2((float)num26, (float)num27);
@@ -12698,6 +12713,7 @@ namespace Terraria
 					vector2 = new Vector2();
 					spriteBatch5.DrawString(spriteFont5, str1, vector220, white5, 0f, vector2, single25, SpriteEffects.None, 0f);
 					num26 = num26 + 70;
+					str1 = string.Format("{0:0,0}", Main.txDataType[b]);
 					SpriteBatch spriteBatch6 = Main.spriteBatch;
 					SpriteFont spriteFont6 = Main.fontMouseText;
 					Vector2 vector221 = new Vector2((float)num26, (float)num27);
@@ -34395,6 +34411,14 @@ namespace Terraria
 			{
 				Console.Write(": ");
 				string lower = Console.ReadLine();
+				if (lower == null)
+				{
+					Console.WriteLine("Quit");
+					WorldFile.saveWorld();
+					Netplay.disconnect = true;
+					SocialAPI.Shutdown();
+					break;
+				}
 				string str = lower;
 				lower = lower.ToLower();
 				try


### PR DESCRIPTION
CTRL+C in the TerrariaServer console now no longer crashes it, but saves the world properly and executes a graceful shutdown, the equivalent of `/quit`.
