### PR TITLE
Fixed world delete problem

### DIFF
--- a/Terraria/Main.cs
+++ b/Terraria/Main.cs
@@ -5919,8 +5919,8 @@ namespace Terraria
 			{
 				if (!Main.WorldList[i].IsCloudSave)
 				{
-					FileOperationAPIWrapper.MoveToRecycleBin(Main.WorldList[i].Path);
-					FileOperationAPIWrapper.MoveToRecycleBin(string.Concat(Main.WorldList[i].Path, ".bak"));
+					File.Delete(Main.WorldList[i].Path);
+					File.Delete(Main.WorldList[i].Path + ".bak");
 				}
 				else if (SocialAPI.Cloud != null)
 				{


### PR DESCRIPTION
Looks like the decompilation generated some funky code for deleting files.

I changed over to using System.IO.File.Delete method.
