### PR TITLE
Add fix for world and autocreate

### DIFF
--- a/Terraria/Main.cs
+++ b/Terraria/Main.cs
@@ -5238,6 +5238,7 @@ namespace Terraria
 			Main.showSplash = false;
 			if (Main.autoGen)
 			{
+				Console.WriteLine("Stand by for new world data.");
 				Main.ActiveWorldFileData = new WorldFileData();
 				Main.ActiveWorldFileData.Path = Main.WorldPathClassic;
 			}
@@ -5255,7 +5256,7 @@ namespace Terraria
 				throw new Exception("When running in the background, the world must be specified with -world <path>");
 			}
 
-			while (Main.worldPathName == null || Main.worldPathName == "")
+			while (Main.worldPathName == null || Main.worldPathName == "" || string.IsNullOrEmpty(Main.WorldPathClassic) == true)
 			{
 				bool flag = true;
 				while (flag)

--- a/Terraria/Main.cs
+++ b/Terraria/Main.cs
@@ -5238,7 +5238,6 @@ namespace Terraria
 			Main.showSplash = false;
 			if (Main.autoGen)
 			{
-				Console.WriteLine("Stand by for new world data.");
 				Main.ActiveWorldFileData = new WorldFileData();
 				Main.ActiveWorldFileData.Path = Main.WorldPathClassic;
 			}

--- a/Terraria/ProgramServer.cs
+++ b/Terraria/ProgramServer.cs
@@ -134,17 +134,6 @@ namespace Terraria
 						num++;
 						ProgramServer.Game.SetWorldName(args[num]);
 					}
-					if (args[num].ToLower() == "-world")
-					{
-						num++;
-
-						if (File.Exists(args[num]) == false)
-						{
-							throw new Exception("Terraria world at path \"" + args[num] + "\" doesn't exist.");
-						}
-
-						ProgramServer.Game.SetWorld(args[num]);
-					}
 					if (args[num].ToLower() == "-motd")
 					{
 						num++;

--- a/TerrariaApi.Server/ServerApi.cs
+++ b/TerrariaApi.Server/ServerApi.cs
@@ -151,6 +151,14 @@ namespace TerrariaApi.Server
 								TraceLevel.Warning);
 							break;
 						}
+						case "-world":
+						{
+							string worldPath = parms[++i];
+							game.SetWorld(worldPath);
+							LogWriter.ServerWriteLine(string.Format("World set for auto loading: {0}", worldPath), TraceLevel.Verbose);
+							
+							break;
+						}
 				}
 			}
 		}


### PR DESCRIPTION
Somehow, world and autocreate were broken in the process of moving those command line arguments back to the API. This set of changes fixes autocreate and world, but conflicts with the changes @tylerjwatson made in regards to an infinite loop on Windows.

Moreover, this issue apparently only solves the issue for me and another Github user, it doesn't solve it for @Cleant.

![](https://dl.dropboxusercontent.com/u/1253613/JaexMadeShareX/2015/07/CWindowssystem32cmd.exe_2015-07-23_13-24-55.png)

https://github.com/NyxStudios/TShock/issues/1050#issuecomment-124213571

Looking for feedback as to what's wrong (why does it produce no output or errors with one person?) and what exactly is causing it.
