### PR TITLE
Fix issue #1056

### DIFF
--- a/Terraria/MessageBuffer.cs
+++ b/Terraria/MessageBuffer.cs
@@ -2319,7 +2319,14 @@ namespace Terraria
 				{
 					int num155 = this.reader.ReadInt16();
 					int num156 = this.reader.ReadInt16();
-					Wiring.HitSwitch(num155, num156);
+					if (num155 < 0 || num155 >= Main.maxTilesX)
+						return;
+					if (num156 < 0 || num156 >= Main.maxTilesY)
+						return;
+					if (Main.tile[num155, num156].type != 135)
+					{
+						Wiring.HitSwitch(num155, num156);
+					}
 					if (Main.netMode != 2)
 					{
 						return;


### PR DESCRIPTION
So, basically. When I added PlayerTriggerPressurePlate hook, I added
SwitchTile back into Update() , in player class. Which caused HitSwitch
to trigger twice. (Once in MessageBuffer, once in SwitchTile).  I
thought the best solution would be to simply modify messagebuffer not to
trigger HitSwitch if its a pressureplate. This way the hook stays fully
functional. And the double trigger issue with pressure plates is fixed.

Link to the issue: https://github.com/NyxStudios/TShock/issues/1056
