### PR TITLE
Fixed halloween check

### DIFF
--- a/Terraria/Main.cs
+++ b/Terraria/Main.cs
@@ -2757,12 +2757,10 @@ namespace Terraria
 			if (day >= 20 && month == 10)
 			{
 				_halloween = true;
-				return;
 			}
 			if (day <= 10 && month == 11)
 			{
 				_halloween = true;
-				return;
 			}
 
 			ServerApi.Hooks.InvokeWorldHalloweenCheck(ref _halloween);

--- a/Terraria/Main.cs
+++ b/Terraria/Main.cs
@@ -2971,7 +2971,6 @@ namespace Terraria
 			if (now.Day >= 15 && now.Month == 12)
 			{
 				xmas = true;
-				return;
 			}
 
 			ServerApi.Hooks.InvokeWorldChristmasCheck(ref xmas);


### PR DESCRIPTION
Halloween mobs currently (TShock 4.3.9) don't spawn, even with ForceHalloween.
From looking at the code, I'd say that ForceHalloween would work outside the actual Halloween date range.
I can't test that right now, since my TShock server is on a shared server and I don't want to break other people's servers.

I think my patch restores the normal Halloween event from Oct 20 to Nov 10.
It still cannot be overridden from true to false by any event handlers, though.
But judging from the original code, that was the intention.
