### PR TITLE
Fix loading of target dummies. Fixes nicatronTg/early-api#16.

### DIFF
--- a/Terraria/DataStructures/TileEntity.cs
+++ b/Terraria/DataStructures/TileEntity.cs
@@ -70,10 +70,6 @@ namespace Terraria.DataStructures
         {
         }
 
-        public virtual void ReadExtraData(BinaryReader reader)
-        {
-        }
-
 		private void ReadInner(BinaryReader reader, bool networkSend)
 		{
 			if (!networkSend)

--- a/Terraria/GameContent/Tile_Entities/TETrainingDummy.cs
+++ b/Terraria/GameContent/Tile_Entities/TETrainingDummy.cs
@@ -122,7 +122,7 @@ namespace Terraria.GameContent.Tile_Entities
 			return tETrainingDummy.ID;
 		}
 
-		public override void ReadExtraData(BinaryReader reader)
+		public override void ReadExtraData(BinaryReader reader, bool networkSend)
 		{
 			this.npc = reader.ReadInt16();
 		}


### PR DESCRIPTION
It looks like `TileEntity.ReadExtraData` had a second overload that shouldn't have been there. It isn't in vanilla, and it was never used. Target dummies implemented that overload and not the other one, which was causing any world with a target dummy to fail to load.
