### PR TITLE
Tile entities may be useful for plugins

### DIFF
--- a/Terraria/GameContent/Tile_Entities/TEItemFrame.cs
+++ b/Terraria/GameContent/Tile_Entities/TEItemFrame.cs
@@ -6,7 +6,7 @@ using Terraria.DataStructures;
 
 namespace Terraria.GameContent.Tile_Entities
 {
-	internal class TEItemFrame : TileEntity
+	public class TEItemFrame : TileEntity
 	{
 		public Item item;
 

--- a/Terraria/GameContent/Tile_Entities/TELogicSensor.cs
+++ b/Terraria/GameContent/Tile_Entities/TELogicSensor.cs
@@ -6,7 +6,7 @@ using Terraria.DataStructures;
 namespace Terraria.GameContent.Tile_Entities
 {
 	// Token: 0x0200021C RID: 540
-	internal class TELogicSensor : TileEntity
+	public class TELogicSensor : TileEntity
 	{
 		// Token: 0x0600127C RID: 4732 RVA: 0x00422A73 File Offset: 0x00420C73
 		public TELogicSensor()

--- a/Terraria/GameContent/Tile_Entities/TETrainingDummy.cs
+++ b/Terraria/GameContent/Tile_Entities/TETrainingDummy.cs
@@ -7,7 +7,7 @@ using Terraria.DataStructures;
 
 namespace Terraria.GameContent.Tile_Entities
 {
-	internal class TETrainingDummy : TileEntity
+	public class TETrainingDummy : TileEntity
 	{
 		private static Dictionary<int, Rectangle> playerBox;
 


### PR DESCRIPTION
I am working on History plugin updates. To be able to restore at least Item Frames, this would be extremely helpful and there is no reason it should be hidden.
