### PR TITLE
Remove extra collision check.

### DIFF
--- a/Terraria/Player.cs
+++ b/Terraria/Player.cs
@@ -27098,7 +27098,7 @@ namespace Terraria
 			{
 				this.FloorVisuals(flag40);
 			}
-			Collision.SwitchTiles(this.position, this.width, this.height, this.oldPosition, 1);
+			//Collision.SwitchTiles(this.position, this.width, this.height, this.oldPosition, 1);
 			PressurePlateHelper.UpdatePlayerPosition(this);
 			this.BordersMovement();
 			this.numMinions = 0;


### PR DESCRIPTION
Stepping on a Pressure Plate appears to play the sound twice.
The ServerAPI player tick does its own pressure plate check and sends another wire packet, which may conflict with some contraptions.
A vanilla server does not run this check.
