### PR TITLE
Don't ignore pressure plates here anymore.

### DIFF
--- a/Terraria/MessageBuffer.cs
+++ b/Terraria/MessageBuffer.cs
@@ -1637,12 +1637,9 @@ namespace Terraria
 						return;
 					if (num156 < 0 || num156 >= Main.maxTilesY)
 						return;
-					if (Main.tile[num155, num156].type != 135)
-					{
-						Wiring.SetCurrentUser(this.whoAmI);
-						Wiring.HitSwitch(num155, num156);
-						Wiring.SetCurrentUser(-1);
-					}
+					Wiring.SetCurrentUser(this.whoAmI);
+					Wiring.HitSwitch(num155, num156);
+					Wiring.SetCurrentUser(-1);
 					NetMessage.SendData(59, -1, this.whoAmI, "", num155, (float)num156, 0f, 0f, 0, 0, 0);
 					return;
 				}


### PR DESCRIPTION
This was here before to allow Collision.SwitchTiles on the server to be able to handle player pressure plates for use with PlayerTriggerPressurePlate (as well as NPC and Projectile pressure plate hooks).

These hooks no longer exist and could be re-implemented without this packet restriction either directly on this packet , or via 'Wiring.CurrentUser' that could be done from inside HitSwitch (or TripWire for a better hook that isn't just Pressure Plates).

This can always be changed back to the existing pressure plate hook system if someone implements the old methods.

If this is not accepted then "remove extra collision check" needs to be reverted (which would bring back the audio bug of double pressure plate tick).
