### PR TITLE
Add missing method :| ItemCheckWrapped

### DIFF
--- a/Terraria/Player.cs
+++ b/Terraria/Player.cs
@@ -11943,6 +11943,22 @@ namespace Terraria
 			}
 		}
 
+		private void ItemCheckWrapped(int i)
+		{
+			if (Main.ignoreErrors)
+			{
+				try
+				{
+					this.ItemCheck(i);
+				}
+				catch
+				{
+				}
+			}
+			else
+				this.ItemCheck(i);
+		}
+
 		public bool ItemFitsItemFrame(Item i)
 		{
 			return i.stack > 0;
@@ -25900,6 +25916,7 @@ namespace Terraria
 			{
 				this.altFunctionUse = 0;
 			}
+			this.ItemCheckWrapped(i);
 			this.PlayerFrame();
 			if (this.mount.Type == 8)
 			{


### PR DESCRIPTION
I'm surprised this didn't break more things. No clue how this method was missing since I was the one who did the full Player class diffing.  (I'll do a second comparison soon, to make sure I didn't miss anything else..) 
I noticed this was missing when releaseUseItem was always false. Which is set in ItemCheck method, what was supposed to be called on in the missing method what I just adddd.
