### PR TITLE
Fix PartyCenter | Add missing PacketTypes

### DIFF
--- a/Terraria/NPC.cs
+++ b/Terraria/NPC.cs
@@ -63583,13 +63583,13 @@ namespace Terraria
 			string result = "";
 			if (this.type == 17)
 			{
-				if (!NPC.downedBoss1 && Main.rand.Next(3) == 0)
+				if (BirthdayParty.PartyIsUp && Main.rand.Next(3) == 0)
 				{
-					if (BirthdayParty.PartyIsUp && Main.rand.Next(3) == 0)
-					{
-						result = Lang.GetBirthdayDialog(this, false);
-					}
-					else if (Main.player[Main.myPlayer].statLifeMax < 200)
+					result = Lang.GetBirthdayDialog(this, false);
+				}
+				else if (!NPC.downedBoss1 && Main.rand.Next(3) == 0)
+				{
+					if (Main.player[Main.myPlayer].statLifeMax < 200)
 					{
 						result = Lang.dialog(1, false);
 					}
@@ -63721,6 +63721,10 @@ namespace Terraria
 			}
 			else if (this.type == 18)
 			{
+				if (BirthdayParty.PartyIsUp && Main.rand.Next(3) == 0)
+				{
+					result = Lang.GetBirthdayDialog(this, false);
+				}
 				if (Main.bloodMoon)
 				{
 					if ((double)Main.player[Main.myPlayer].statLife < (double)Main.player[Main.myPlayer].statLifeMax2 * 0.66)

--- a/Terraria/NetMessage.cs
+++ b/Terraria/NetMessage.cs
@@ -267,12 +267,12 @@ namespace Terraria
 					bb7[5] = NPC.downedChristmasTree;
 					bb7[6] = NPC.downedGolemBoss; 
 					bb7[7] = BirthdayParty.PartyIsUp;
+					writer.Write(bb7);
 					BitsByte bb8 = 0;
 					bb8[0] = NPC.downedPirates;
 					bb8[1] = NPC.downedFrost;
 					bb8[2] = NPC.downedGoblins;
 					writer.Write(bb8);
-					writer.Write(bb7);
 					writer.Write((sbyte) Main.invasionType);
 					writer.Write(Main.LobbyId);
 					break;

--- a/TerrariaApi.Server/PacketTypes.cs
+++ b/TerrariaApi.Server/PacketTypes.cs
@@ -112,5 +112,7 @@ public enum PacketTypes
 	SmartTextMessage = 107,
 	WiredCannonShot = 108,
 	MassWireOperation = 109,
-	MassWireOperationPay = 110
+	MassWireOperationPay = 110,
+	ToggleParty = 111,
+	TreeGrowFX = 112
 }


### PR DESCRIPTION
Writing bitsbyte was in wrong order which didn't update client's, that
its party time! :dancer:
Also missing packets from packettype made new packets not trigger at all
since there is a check for non existing packets what makes code return.

Also add some missing NPC birthday dialog.
(Obviously willing to change PacketType name if requested)
