### PR TITLE
Traveling Merchant now sells Shingles only when selling Dynasty Wood

### DIFF
--- a/Terraria/Chest.cs
+++ b/Terraria/Chest.cs
@@ -2163,7 +2163,7 @@ namespace Terraria
 				num2++;
 				Main.travelShop[num1] = num3;
 				num1++;
-				if (num3 != 2260)
+				if (num3 == 2260)
 				{
 					Main.travelShop[num1] = 2261;
 					num1++;


### PR DESCRIPTION
The Traveling Merchant was selling way too many Dynasty Shingles. This should fix it.
