### PR TITLE
Prevent FindNextOpenClientSlot from returning duplicate IDs if called…

### DIFF
--- a/Terraria/Netplay.cs
+++ b/Terraria/Netplay.cs
@@ -29,7 +29,7 @@ namespace Terraria
 		public static bool spamCheck = false;
 		public static bool anyClients = false;
 
-        public static readonly object syncRoot = new object();
+		public static readonly object syncRoot = new object();
 
 		public static void ResetNetDiag()
 		{
@@ -154,16 +154,16 @@ namespace Terraria
 		}
 		private static int FindNextOpenClientSlot()
 		{
-            lock (syncRoot)
-            {
-                for (int i = 0; i < Main.maxNetPlayers; i++)
-                {
-                    if (!Clients[i].Socket.IsConnected())
-                    {
-                        return i;
-                    }
-                }
-            }
+			lock (syncRoot)
+			{
+				for (int i = 0; i < Main.maxNetPlayers; i++)
+				{
+					if (!Clients[i].Socket.IsConnected())
+					{
+						return i;
+					}
+				}
+			}
 
 			return -1;
 		}

--- a/Terraria/Netplay.cs
+++ b/Terraria/Netplay.cs
@@ -29,6 +29,8 @@ namespace Terraria
 		public static bool spamCheck = false;
 		public static bool anyClients = false;
 
+        public static readonly object syncRoot = new object();
+
 		public static void ResetNetDiag()
 		{
 			Main.rxMsg = 0;
@@ -152,13 +154,17 @@ namespace Terraria
 		}
 		private static int FindNextOpenClientSlot()
 		{
-			for (int i = 0; i < Main.maxNetPlayers; i++)
-			{
-				if (!Clients[i].Socket.IsConnected())
-				{
-					return i;
-				}
-			}
+            lock (syncRoot)
+            {
+                for (int i = 0; i < Main.maxNetPlayers; i++)
+                {
+                    if (!Clients[i].Socket.IsConnected())
+                    {
+                        return i;
+                    }
+                }
+            }
+
 			return -1;
 		}
 		private static void OnConnectionAccepted(ISocket client)


### PR DESCRIPTION
… simultaneously in a multi-thread scenario.

This places a more granular locks in the `FindNextOpenClientSlot` method, effectively preventing it from returning duplicate IDs if ever called in parallel.  It's the same fix as #108 but not locking against network I/O which is a good candidate for deadlocks.

I am going to need testing.