### PR TITLE
Updated OTAPI for worldmap removal

### DIFF
--- a/TShock.Modifications.Bootstrapper/TShock.Modifications.Bootstrapper.csproj
+++ b/TShock.Modifications.Bootstrapper/TShock.Modifications.Bootstrapper.csproj
@@ -69,8 +69,9 @@
       <HintPath>..\packages\NuGet.Core.2.12.0\lib\net40-Client\NuGet.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="OTAPI">
-      <HintPath>..\packages\OTAPI.2.0.0.15\lib\net451\OTAPI.dll</HintPath>
+    <Reference Include="OTAPI, Version=1.3.4.4, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\OTAPI.2.0.0.16\lib\net451\OTAPI.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="OTAPI.Patcher.Engine">
       <HintPath>..\prebuilt\OTAPI.Patcher.Engine.dll</HintPath>

--- a/TShock.Modifications.Bootstrapper/packages.config
+++ b/TShock.Modifications.Bootstrapper/packages.config
@@ -6,5 +6,5 @@
   <package id="NDesk.Options" version="0.2.1" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
   <package id="NuGet.Core" version="2.12.0" targetFramework="net452" />
-  <package id="OTAPI" version="2.0.0.15" targetFramework="net452" />
+  <package id="OTAPI" version="2.0.0.16" targetFramework="net452" />
 </packages>

--- a/TShock.Modifications.SSC/TShock.Modifications.SSC.csproj
+++ b/TShock.Modifications.SSC/TShock.Modifications.SSC.csproj
@@ -51,8 +51,9 @@
       <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="OTAPI">
-      <HintPath>..\packages\OTAPI.2.0.0.15\lib\net451\OTAPI.dll</HintPath>
+    <Reference Include="OTAPI, Version=1.3.4.4, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\OTAPI.2.0.0.16\lib\net451\OTAPI.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="OTAPI.Patcher.Engine">
       <HintPath>..\prebuilt\OTAPI.Patcher.Engine.dll</HintPath>

--- a/TShock.Modifications.SSC/packages.config
+++ b/TShock.Modifications.SSC/packages.config
@@ -2,5 +2,5 @@
 <packages>
   <package id="Mono.Cecil" version="0.9.6.4" targetFramework="net452" />
   <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net452" />
-  <package id="OTAPI" version="2.0.0.15" targetFramework="net452" />
+  <package id="OTAPI" version="2.0.0.16" targetFramework="net452" />
 </packages>


### PR DESCRIPTION
Frees up memory usage after removing the client side World Map code
Adds Player, Npc, Item & Projectile update hooks