### PR TITLE
Recursive assembly resolver (again)

### DIFF
--- a/TerrariaServerAPI/TerrariaApi.Server/ServerApi.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/ServerApi.cs
@@ -421,15 +421,24 @@ namespace TerrariaApi.Server
 		private static Assembly CurrentDomain_AssemblyResolve(object sender, ResolveEventArgs args)
 		{
 			string fileName = args.Name.Split(',')[0];
-			string path = Path.Combine(ServerPluginsDirectoryPath, fileName + ".dll");
+			string dir = Directory.GetParent(ServerPluginsDirectoryPath).FullName;
+
+			IEnumerable<string> paths =
+				Directory.EnumerateFiles(dir, "*.dll", SearchOption.AllDirectories)
+				.Concat(Directory.EnumerateFiles(dir, "*.dll-plugin", SearchOption.AllDirectories));
+
 			try
 			{
-				if (File.Exists(path))
+				string targetFile = paths.FirstOrDefault(
+					file => Path.GetFileName(file ?? "").Equals(fileName + ".dll", StringComparison.OrdinalIgnoreCase) ||
+					        Path.GetFileName(file ?? "").Equals(fileName + ".dll-plugin", StringComparison.OrdinalIgnoreCase));
+
+				if (File.Exists(targetFile))
 				{
 					Assembly assembly;
 					if (!loadedAssemblies.TryGetValue(fileName, out assembly))
 					{
-						assembly = Assembly.Load(File.ReadAllBytes(path));
+						assembly = Assembly.Load(File.ReadAllBytes(targetFile));
 						// We just do this to return a proper error message incase this is a resolved plugin assembly
 						// referencing an old TerrariaServer version.
 						if (!InvalidateAssembly(assembly, fileName))


### PR DESCRIPTION
This one searches the root directory (where `TerrariaServer.exe` located) to resolve otherwise unlocatable `Newtonsoft.Json`.
Alternative could be copying `Newtonsoft.Json.dll` in `ServerPlugins/` or one of its subdirectories.