### PR TITLE
Revert "Search for plugins recursively"

### DIFF
--- a/TerrariaServerAPI/TerrariaApi.Server/ServerApi.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/ServerApi.cs
@@ -244,8 +244,8 @@ namespace TerrariaApi.Server
 			if (File.Exists(ignoredPluginsFilePath))
 				ignoredFiles.AddRange(File.ReadAllLines(ignoredPluginsFilePath));
 
-			List<FileInfo> fileInfos = new DirectoryInfo(ServerPluginsDirectoryPath).GetFiles("*.dll", SearchOption.AllDirectories).ToList();
-			fileInfos.AddRange(new DirectoryInfo(ServerPluginsDirectoryPath).GetFiles("*.dll-plugin", SearchOption.AllDirectories));
+			List<FileInfo> fileInfos = new DirectoryInfo(ServerPluginsDirectoryPath).GetFiles("*.dll").ToList();
+			fileInfos.AddRange(new DirectoryInfo(ServerPluginsDirectoryPath).GetFiles("*.dll-plugin"));
 
 			Dictionary<TerrariaPlugin, Stopwatch> pluginInitWatches = new Dictionary<TerrariaPlugin, Stopwatch>();
 			foreach (FileInfo fileInfo in fileInfos)


### PR DESCRIPTION
Reverts NyxStudios/TerrariaAPI-Server#127.

This is so we can return to our old plugin-loading functionality until we fix the recursive resolver