### PR TITLE
Replace Enum.IsDefined with higher performance alternative

### DIFF
--- a/TerrariaServerAPI/TerrariaApi.Server/Hooking/NetHooks.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/Hooking/NetHooks.cs
@@ -1,5 +1,6 @@
 ﻿using OTAPI;
 using System;
+using System.Collections.Generic;
 using Terraria;
 using Terraria.Localization;
 using Microsoft.Xna.Framework;
@@ -75,6 +76,8 @@ namespace TerrariaApi.Server.Hooking
 			}
 			return HookResult.Continue;
 		}
+		
+		static HashSet<int> _validPackets = new HashSet<int>(Enum.GetValues(typeof(PacketTypes)).Cast<int>());
 
 		static HookResult OnReceiveData(
 			MessageBuffer buffer,
@@ -84,7 +87,7 @@ namespace TerrariaApi.Server.Hooking
 			ref int length
 		)
 		{
-			if (!Enum.IsDefined(typeof(PacketTypes), (int)packetId))
+			if (!_validPackets.Contains(packetId))
 			{
 				return HookResult.Cancel;
 			}


### PR DESCRIPTION
Enum.IsDefined is a noticeable performance hit as shown below:
![image](https://user-images.githubusercontent.com/5434547/28245459-db54d98e-6a0f-11e7-96ac-a5c633d22af8.png)

The new `HashSet` is constructed only once and is used for much less overhead lookup to verify a packet's validness.

http://www.philosophicalgeek.com/2012/03/27/performance-and-other-issues-with-system-enum/
https://gururajb.wordpress.com/2008/12/24/enum-isdefined-and-performance-issue/
https://goldfishforthought.blogspot.com/2008/03/isbadenumisdefined-true.html