### PR TITLE
Possible fix to -world not working correctly

### DIFF
--- a/TerrariaServerAPI/TerrariaApi.Server/ServerApi.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/ServerApi.cs
@@ -191,6 +191,9 @@ namespace TerrariaApi.Server
 						{
 							game.SetWorld(arg.Value, false);
 
+							Main.WorldPath = Path.GetDirectoryName(arg.Value);
+							Main.worldName = Path.GetFileNameWithoutExtension(arg.Value);
+
 							break;
 						}
 					case "-motd":

--- a/TerrariaServerAPI/TerrariaApi.Server/ServerApi.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/ServerApi.cs
@@ -191,8 +191,9 @@ namespace TerrariaApi.Server
 						{
 							game.SetWorld(arg.Value, false);
 
-							Main.WorldPath = Path.GetDirectoryName(arg.Value);
-							Main.worldName = Path.GetFileNameWithoutExtension(arg.Value);
+							var full_path = Path.GetFullPath(arg.Value);
+							Main.WorldPath = Path.GetDirectoryName(full_path);
+							Main.worldName = Path.GetFileNameWithoutExtension(full_path);
 
 							break;
 						}


### PR DESCRIPTION
Basically you currently have to specify -world, -worldpath & -worldname for the server to generate a world and reuse it.
This commit should accept just -world and auto populate the other two variables. My initial thoughts were to only set it when they were blank but Main.WorldPath always defaults to My Games\Terraria, and also if you are specifying -world you are specifying the name, path and file all-in-one anyway.

If someone else could test this (ideally many people), that would be great.
Refers to : https://github.com/Pryaxis/TShock/issues/1483