### PR TITLE
Remove packets that aren't used

### DIFF
--- a/TerrariaServerAPI/TerrariaApi.Server/PacketTypes.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/PacketTypes.cs
@@ -16,8 +16,6 @@ public enum PacketTypes
 	PlayerSpawn = 12,
 	PlayerUpdate = 13,
 	PlayerActive = 14,
-	[Obsolete]
-	SyncPlayers = 15,
 	PlayerHp = 16,
 	Tile = 17,
 	TimeSet = 18,
@@ -27,8 +25,6 @@ public enum PacketTypes
 	ItemOwner = 22,
 	NpcUpdate = 23,
 	NpcItemStrike = 24,
-	[Obsolete("ChatText is not used anymore. See packet 82.", true)]
-	ChatText = 25,
 	PlayerDamage = 26,
 	ProjectileNew = 27,
 	NpcStrike = 28,
@@ -47,7 +43,6 @@ public enum PacketTypes
 	PlayerAnimation = 41,
 	PlayerMana = 42,
 	EffectMana = 43,
-	PlayerKillMe = 44,
 	PlayerTeam = 45,
 	SignRead = 46,
 	SignNew = 47,

--- a/TerrariaServerAPI/TerrariaApi.Server/PacketTypes.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/PacketTypes.cs
@@ -25,7 +25,6 @@ public enum PacketTypes
 	ItemOwner = 22,
 	NpcUpdate = 23,
 	NpcItemStrike = 24,
-	PlayerDamage = 26,
 	ProjectileNew = 27,
 	NpcStrike = 28,
 	ProjectileDestroy = 29,


### PR DESCRIPTION
This should only be merged after https://github.com/Pryaxis/TShock/pull/1527 is merged. We don't need to keep old packet types around, and I'm removing anything that uses them from TShock. We've kept them around for compiling reasons, but it's honestly stupid that we did this.