### PR TITLE
Make TSAPI fetch OTAPI from the correct folder

### DIFF
--- a/TerrariaServerAPI/TerrariaServerAPI.csproj
+++ b/TerrariaServerAPI/TerrariaServerAPI.csproj
@@ -97,7 +97,7 @@
       <HintPath>..\packages\Newtonsoft.Json.10.0.3\lib\net45\Newtonsoft.Json.dll</HintPath>
     </Reference>
     <Reference Include="OTAPI">
-      <HintPath>..\TShock.Modifications.Bootstrapper\bin\Debug\Output\OTAPI.dll</HintPath>
+      <HintPath>..\TShock.Modifications.Bootstrapper\bin\$(ConfigurationName)\Output\OTAPI.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.IO.Compression" />


### PR DESCRIPTION
Fixes build issues for non-debug configurations.

Must be merged alongside https://github.com/Pryaxis/TShock/pull/1547