### PR TITLE
Fix Patcher referencing /bin/Debug explicitly

### DIFF
--- a/TShock.Modifications.Bootstrapper/Program.cs
+++ b/TShock.Modifications.Bootstrapper/Program.cs
@@ -15,15 +15,31 @@ namespace TShock.Modifications.Bootstrapper
 			string sourceAsm = null;
 			string modificationGlob = null;
 			string outputPath = null;
+			string folder = null;
 
 			Console.WriteLine("TShock Mintaka Bootstrapper, Open Terraria API v2.0");
+
+			if (File.Exists("env.config"))
+			{
+				using (StreamReader sr = File.OpenText("env.config"))
+				{
+					folder = sr.ReadLine();
+					Console.WriteLine($"Folder set to: " + folder);
+				}
+			}
+			else
+			{
+				Console.WriteLine("Something went wrong! (env.config not found)");
+				Console.ReadLine();
+				return;
+			}
 
 			if (args.Length == 0)
 			{
 				args = new[]
 				{
 					"-in=OTAPI.dll",
-					"-mod=" + Path.Combine("..", "..", "..", "TShock.Modifications.**", "bin", "Debug", "TShock.Modifications.*.dll"),
+					"-mod=" + Path.Combine("..", "..", "..", "TShock.Modifications.**", "bin", folder, "TShock.Modifications.*.dll"),
 					"-o=" + Path.Combine("Output", "OTAPI.dll")
 				};
 			}

--- a/TShock.Modifications.Bootstrapper/Program.cs
+++ b/TShock.Modifications.Bootstrapper/Program.cs
@@ -19,23 +19,22 @@ namespace TShock.Modifications.Bootstrapper
 
 			Console.WriteLine("TShock Mintaka Bootstrapper, Open Terraria API v2.0");
 
-			if (File.Exists("env.config"))
-			{
-				using (StreamReader sr = File.OpenText("env.config"))
-				{
-					folder = sr.ReadLine();
-					Console.WriteLine($"Folder set to: " + folder);
-				}
-			}
-			else
-			{
-				Console.WriteLine("Something went wrong! (env.config not found)");
-				Console.ReadLine();
-				return;
-			}
-
 			if (args.Length == 0)
 			{
+				if (File.Exists("env.config"))
+				{
+					using (StreamReader sr = File.OpenText("env.config"))
+					{
+						folder = sr.ReadLine();
+						Console.WriteLine($"Folder set to: " + folder);
+					}
+				}
+				else
+				{
+					Console.WriteLine("Something went wrong! (env.config not found)");
+					Console.ReadLine();
+					return;
+				}
 				args = new[]
 				{
 					"-in=OTAPI.dll",

--- a/TShock.Modifications.Bootstrapper/TShock.Modifications.Bootstrapper.csproj
+++ b/TShock.Modifications.Bootstrapper/TShock.Modifications.Bootstrapper.csproj
@@ -90,6 +90,9 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <PropertyGroup>
+    <PreBuildEvent>echo $(ConfigurationName) &gt;&gt; $(TargetDir)\env.config</PreBuildEvent>
+  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">
@@ -97,9 +100,4 @@
   <Target Name="AfterBuild">
   </Target>
   -->
-  <Target Name="BeforeBuild">
-    <WriteLinesToFile File="$(OutputPath)\env.config" 
-                      Lines="$(ConfigurationName)" Overwrite="true">
-    </WriteLinesToFile>
-</Target>
 </Project>

--- a/TShock.Modifications.Bootstrapper/TShock.Modifications.Bootstrapper.csproj
+++ b/TShock.Modifications.Bootstrapper/TShock.Modifications.Bootstrapper.csproj
@@ -97,4 +97,9 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <Target Name="BeforeBuild">
+    <WriteLinesToFile File="$(OutputPath)\env.config" 
+                      Lines="$(ConfigurationName)" Overwrite="true">
+    </WriteLinesToFile>
+</Target>
 </Project>


### PR DESCRIPTION
Oversight from my previous PR. Sincere apologies for missing it while testing.  
  
The patcher now outputs the configuration name to env.config pre-build, and then reads it at runtime to determine which folder the modifications should be searched for inside of. This one was tested and works correctly.  
There will be a TShock submodule update right after this is merged, so please accept that as well 👍 