### PR TITLE
Enable 1-click bootstrapping in Visual Studio

### DIFF
--- a/TShock.Modifications.Bootstrapper/TShock.Modifications.Bootstrapper.csproj
+++ b/TShock.Modifications.Bootstrapper/TShock.Modifications.Bootstrapper.csproj
@@ -101,6 +101,7 @@
   </Target>
   -->
   <Target Name="BeforeBuild">
+    <MakeDir Directories="$(OutputPath)" />
     <WriteLinesToFile File="$(OutputPath)\env.config" 
                       Lines="$(ConfigurationName)" Overwrite="true">
     </WriteLinesToFile>

--- a/TShock.Modifications.Bootstrapper/TShock.Modifications.Bootstrapper.csproj
+++ b/TShock.Modifications.Bootstrapper/TShock.Modifications.Bootstrapper.csproj
@@ -100,4 +100,9 @@
   <Target Name="AfterBuild">
   </Target>
   -->
+  <Target Name="BeforeBuild">
+    <WriteLinesToFile File="$(OutputPath)\env.config" 
+                      Lines="$(ConfigurationName)" Overwrite="true">
+    </WriteLinesToFile>
+  </Target>
 </Project>

--- a/TShock.Modifications.Bootstrapper/TShock.Modifications.Bootstrapper.csproj
+++ b/TShock.Modifications.Bootstrapper/TShock.Modifications.Bootstrapper.csproj
@@ -90,9 +90,6 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PreBuildEvent>echo $(ConfigurationName) &gt;&gt; $(TargetDir)\env.config</PreBuildEvent>
-  </PropertyGroup>
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">


### PR DESCRIPTION
Fixes a regression from a55a1787803abd50fbae98d093c7a3cbf19c5297.

Visual Studio can't run echo (for pre-build tasks). This should work on both *command line environments* as well as 1-click bootstrapping from Visual Studio.

This is in reference to #156.