### PR TITLE
PacketTypes.TileKill -> PacketTypes.PlaceChest

### DIFF
--- a/TerrariaServerAPI/TerrariaApi.Server/PacketTypes.cs
+++ b/TerrariaServerAPI/TerrariaApi.Server/PacketTypes.cs
@@ -37,7 +37,7 @@ public enum PacketTypes
 	ChestGetContents = 31,
 	ChestItem = 32,
 	ChestOpen = 33,
-	TileKill = 34,
+	PlaceChest = 34,
 	EffectHeal = 35,
 	Zones = 36,
 	PasswordRequired = 37,


### PR DESCRIPTION
The [docs](https://tshock.readme.io/docs/multiplayer-packet-structure) claim that packet 34 is not tile kill. It's place chest. The code agrees, so I'm inclined to believe this needs to change.